### PR TITLE
feat(ci): add version bump and auto-merge workflow

### DIFF
--- a/.github/workflows/bump-version-and-merge.yml
+++ b/.github/workflows/bump-version-and-merge.yml
@@ -18,37 +18,130 @@ on:
       merge_method:
         description: Merge strategy
         required: true
-        default: squash
+        default: merge
         type: choice
         options:
-          - squash
           - merge
+          - squash
           - rebase
+  issue_comment:
+    types:
+      - created
 
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
-  group: bump-and-merge-pr-${{ inputs.pr_number }}
+  group: bump-and-merge-pr-${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
   bump-and-merge:
     runs-on: ubuntu-latest
     steps:
-      - name: Read pull request metadata
-        id: pr
+      - name: Resolve trigger request
+        id: request
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumberRaw = '${{ inputs.pr_number }}'.trim();
-            const prNumber = Number(prNumberRaw);
+            const { owner, repo } = context.repo;
+            const allowedUser = 'oimasterkafuu';
+            const eventName = context.eventName;
+            const bumpTypes = new Set(['major', 'minor', 'patch']);
+            const mergeMethods = new Set(['merge', 'squash', 'rebase']);
 
-            if (!Number.isInteger(prNumber) || prNumber <= 0) {
-              core.setFailed(`Invalid pr_number: "${prNumberRaw}"`);
+            let shouldRun = true;
+            let prNumber = null;
+            let bumpType = null;
+            let mergeMethod = 'merge';
+
+            if (eventName === 'workflow_dispatch') {
+              const inputs = context.payload.inputs || {};
+              const prNumberRaw = String(inputs.pr_number || '').trim();
+              prNumber = Number(prNumberRaw);
+              bumpType = String(inputs.bump_type || '').trim().toLowerCase();
+              mergeMethod = String(inputs.merge_method || 'merge').trim().toLowerCase();
+
+              if (!Number.isInteger(prNumber) || prNumber <= 0) {
+                core.setFailed(`Invalid pr_number: "${prNumberRaw}"`);
+                return;
+              }
+
+              if (!bumpTypes.has(bumpType)) {
+                core.setFailed(`Invalid bump_type: "${bumpType}"`);
+                return;
+              }
+
+              if (!mergeMethods.has(mergeMethod)) {
+                core.setFailed(`Invalid merge_method: "${mergeMethod}"`);
+                return;
+              }
+            } else if (eventName === 'issue_comment') {
+              const issue = context.payload.issue;
+              const comment = context.payload.comment;
+              const commentUser = String(comment?.user?.login || '');
+
+              if (!issue?.pull_request) {
+                shouldRun = false;
+                core.info('Ignore issue comment because it is not on a pull request.');
+              } else if (commentUser.toLowerCase() !== allowedUser.toLowerCase()) {
+                shouldRun = false;
+                core.info(`Ignore comment from non-authorized user: ${commentUser}`);
+              } else {
+                prNumber = Number(issue.number);
+                const body = String(comment?.body || '').trim();
+                const match = /^OK\.\s*(major|minor|patch)(?:\s+(merge|squash|rebase))?$/i.exec(body);
+
+                if (!match) {
+                  shouldRun = false;
+
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    body: [
+                      'Comment format is invalid.',
+                      '',
+                      'Use one of these commands:',
+                      '- `OK. major`',
+                      '- `OK. minor`',
+                      '- `OK. patch`',
+                      '',
+                      'Optional merge strategy:',
+                      '- `OK. patch merge`',
+                      '- `OK. patch squash`',
+                      '- `OK. patch rebase`'
+                    ].join('\n')
+                  });
+                } else {
+                  bumpType = match[1].toLowerCase();
+                  mergeMethod = (match[2] || 'merge').toLowerCase();
+                }
+              }
+            } else {
+              shouldRun = false;
+              core.info(`Ignore unsupported event: ${eventName}`);
+            }
+
+            core.setOutput('should_run', String(shouldRun));
+            if (!shouldRun) {
               return;
             }
+
+            core.info(`Request accepted: pr #${prNumber}, bump=${bumpType}, merge=${mergeMethod}`);
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('bump_type', bumpType);
+            core.setOutput('merge_method', mergeMethod);
+
+      - name: Read pull request metadata
+        id: pr
+        if: steps.request.outputs.should_run == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.request.outputs.pr_number }}');
 
             const { owner, repo } = context.repo;
             const { data: pr } = await github.rest.pulls.get({
@@ -76,27 +169,32 @@ jobs:
             core.info(`Will bump ${pr.head.ref} and merge into ${pr.base.ref}.`);
             core.setOutput('pr_number', String(prNumber));
             core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('base_ref', pr.base.ref);
 
       - name: Checkout pull request branch
+        if: steps.request.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 0
 
       - name: Setup Node.js
+        if: steps.request.outputs.should_run == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: Enable Corepack
+        if: steps.request.outputs.should_run == 'true'
         run: corepack enable
 
       - name: Bump package version
         id: bump
+        if: steps.request.outputs.should_run == 'true'
         run: |
           old_version="$(node -p "require('./package.json').version")"
-          pnpm version "${{ inputs.bump_type }}" --no-git-tag-version
+          pnpm version "${{ steps.request.outputs.bump_type }}" --no-git-tag-version
           new_version="$(node -p "require('./package.json').version")"
 
           echo "old_version=${old_version}" >> "$GITHUB_OUTPUT"
@@ -104,6 +202,7 @@ jobs:
           echo "Version bumped: ${old_version} -> ${new_version}"
 
       - name: Commit and push version change
+        if: steps.request.outputs.should_run == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -121,26 +220,106 @@ jobs:
           git commit -m "chore(release): bump version to v${{ steps.bump.outputs.new_version }}"
           git push origin "HEAD:${{ steps.pr.outputs.head_ref }}"
 
+      - name: Check merge conflicts with base branch
+        id: merge_check
+        if: steps.request.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ steps.pr.outputs.base_ref }}"
+
+          if git merge --no-commit --no-ff "origin/${{ steps.pr.outputs.base_ref }}"; then
+            echo "merge_conflict=false" >> "$GITHUB_OUTPUT"
+            echo "conflict_files=" >> "$GITHUB_OUTPUT"
+            git merge --abort
+          else
+            echo "merge_conflict=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "conflict_files<<EOF"
+              git diff --name-only --diff-filter=U
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            git merge --abort || git reset --hard HEAD
+          fi
+
+      - name: Comment conflict details
+        if: steps.request.outputs.should_run == 'true' && steps.merge_check.outputs.merge_conflict == 'true'
+        uses: actions/github-script@v7
+        env:
+          CONFLICT_FILES: ${{ steps.merge_check.outputs.conflict_files }}
+          BUMP_TYPE: ${{ steps.request.outputs.bump_type }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = Number('${{ steps.pr.outputs.pr_number }}');
+            const files = String(process.env.CONFLICT_FILES || '')
+              .split('\n')
+              .map((item) => item.trim())
+              .filter(Boolean);
+            const conflictList =
+              files.length > 0
+                ? files.map((item) => `- \`${item}\``).join('\n')
+                : '- (unable to detect files)';
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body: [
+                `Version was bumped to \`v${process.env.NEW_VERSION}\`, but auto-merge failed because of conflicts against \`${process.env.BASE_REF}\`.`,
+                '',
+                'Please resolve conflicts manually, push your fix branch, then comment again:',
+                `- \`OK. ${process.env.BUMP_TYPE}\``,
+                '',
+                'Conflict files:',
+                conflictList
+              ].join('\n')
+            });
+
+      - name: Stop after conflict report
+        if: steps.request.outputs.should_run == 'true' && steps.merge_check.outputs.merge_conflict == 'true'
+        run: |
+          echo "Conflicts detected. Manual resolution required."
+          exit 1
+
       - name: Merge pull request
+        if: steps.request.outputs.should_run == 'true' && steps.merge_check.outputs.merge_conflict != 'true'
         uses: actions/github-script@v7
         with:
           script: |
             const { owner, repo } = context.repo;
             const prNumber = Number('${{ steps.pr.outputs.pr_number }}');
-            const mergeMethod = '${{ inputs.merge_method }}';
+            const mergeMethod = '${{ steps.request.outputs.merge_method }}';
             const newVersion = '${{ steps.bump.outputs.new_version }}';
 
-            const mergeRequest = {
-              owner,
-              repo,
-              pull_number: prNumber,
-              merge_method: mergeMethod
-            };
+            try {
+              const mergeRequest = {
+                owner,
+                repo,
+                pull_number: prNumber,
+                merge_method: mergeMethod
+              };
 
-            if (mergeMethod !== 'rebase') {
-              mergeRequest.commit_title = `chore(release): merge #${prNumber} with v${newVersion}`;
+              if (mergeMethod !== 'rebase') {
+                mergeRequest.commit_title = `chore(release): merge #${prNumber} with v${newVersion}`;
+              }
+
+              const { data } = await github.rest.pulls.merge(mergeRequest);
+              core.info(`Merged PR #${prNumber}: ${data.sha}`);
+            } catch (error) {
+              const message = error?.message || String(error);
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: [
+                  `Version was bumped to \`v${newVersion}\`, but merge failed through GitHub API.`,
+                  '',
+                  'Please check branch protection/status checks or resolve conflicts manually.',
+                  '',
+                  `Error: \`${message}\``
+                ].join('\n')
+              });
+              throw error;
             }
-
-            const { data } = await github.rest.pulls.merge(mergeRequest);
-
-            core.info(`Merged PR #${prNumber}: ${data.sha}`);

--- a/README.md
+++ b/README.md
@@ -14,20 +14,24 @@ pnpm run start
 
 ## GitHub Action：升级版本并自动合并 PR
 
-新增了一个手动触发的 workflow：`Bump Version And Merge PR`。
+新增了一个 workflow：`Bump Version And Merge PR`，支持「手动触发」和「PR 评论触发」。
 
 使用方式：
 
-1. 打开 GitHub 仓库的 `Actions` 页面。
-2. 选择 `Bump Version And Merge PR`。
-3. 点击 `Run workflow`，填写：
+1. 推荐：在 PR 中评论触发（仅限 `oimasterkafuu`）：
+   - `OK. major`
+   - `OK. minor`
+   - `OK. patch`
+   - 可选指定合并策略：`OK. patch merge|squash|rebase`（默认 `merge`）
+2. 也可在 Actions 页面手动 `Run workflow`：
    - `pr_number`：要处理的 PR 编号
    - `bump_type`：版本升级类型（`major` / `minor` / `patch`）
-   - `merge_method`：合并方式（`squash` / `merge` / `rebase`）
-4. 运行后会自动完成：
+   - `merge_method`：合并方式（`merge` / `squash` / `rebase`）
+3. 运行后会自动完成：
    - 在 PR 分支执行 `pnpm version <bump_type> --no-git-tag-version`
    - 提交并推送 `package.json`（以及 `pnpm-lock.yaml`，如果有变化）
-   - 自动 merge 该 PR
+   - 先检测与目标分支是否冲突
+   - 无冲突则自动 merge；有冲突则在 PR 留言提示冲突文件并停止
 
 注意事项：
 


### PR DESCRIPTION
## Summary
- add a workflow to bump semantic version (major/minor/patch) before merge
- support selecting merge method (squash/merge/rebase)
- update README with usage and constraints

## Verification
- pnpm run format
- pnpm run lint
- pnpm run build